### PR TITLE
Update gd32vf103.h

### DIFF
--- a/Firmware/GD32VF103_standard_peripheral/gd32vf103.h
+++ b/Firmware/GD32VF103_standard_peripheral/gd32vf103.h
@@ -177,7 +177,12 @@ typedef enum IRQn
 
 /* enum definitions */
 typedef enum {DISABLE = 0, ENABLE = !DISABLE} EventStatus, ControlStatus;
-typedef enum {FALSE = 0, TRUE = !FALSE} bool;
+#ifdef __cplusplus
+    #define TRUE true
+    #define FALSE false 
+#else
+    typedef enum {FALSE = 0, TRUE = !FALSE} bool;
+#endif /* __cplusplus */
 typedef enum {RESET = 0, SET = !RESET} FlagStatus;
 typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrStatus;
 


### PR DESCRIPTION
### Fix bool definition conflict for projects mixed with C++ code

The `bool` type is granted in the C++ language.
For C++ projects using the GD32VF103_Firmware_Library, this redefinition of the `bool` type will prevent it to build correctly.

This patch keeps compatibility with the GD32VF103_Firmware_Library when using it with C only projects.

Thank you.
@sharpgeek 